### PR TITLE
Add `GHQ_ROOT` to workflow variables to change ghq root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Simple yet powerful workflow that opens your project under the [ghq](https://git
 1. download the [ghq.alfredworkflow](https://github.com/jackchuka/alfred-workflow-ghq/releases/latest) file
 2. open the file
 3. update environment variable `PATH_TO_APP` as your need, i.e. `/Applications/IntelliJ IDEA.app`
+4. (Not Required) update environment variable `GHQ_ROOT` as your need, i.e. `/Users/jackchuka/src`

--- a/info.plist
+++ b/info.plist
@@ -254,12 +254,15 @@ ghq get {query}</string>
 	</dict>
 	<key>variables</key>
 	<dict>
+		<key>GHQ_ROOT</key>
+		<string></string>
 		<key>PATH_TO_APP</key>
 		<string>/Applications/IntelliJ IDEA.app</string>
 	</dict>
 	<key>variablesdontexport</key>
 	<array>
 		<string>PATH_TO_APP</string>
+		<string>GHQ_ROOT</string>
 	</array>
 	<key>version</key>
 	<string></string>


### PR DESCRIPTION
Hi @jackchuka !

`ghq root` can be changed in several ways, but this workflow does not recognize the change.
Using `GHQ_ROOT` as workflow variable, we can fix this problem.